### PR TITLE
Update README and packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 This tool allows you to test your output of an engine against our internal schemas.
 
+## Install
+
+Clone:
+`git clone guardrailsio/guardrails-engine-output-schema-validator`
+
+Install dependencies
+`npm install`
+
+Install into system
+`npm link`
+
 ## Usage
 
 ```shell
@@ -64,13 +75,3 @@ In some cases you will run into validation errors. Those look like this:
 
   Usually the validation error is fairly straight forward and gives you enough infos to fix the issue.
 
-## Install
-
-Clone:
-`git clone guardrailsio/guardrails-engine-output-schema-validator`
-
-Install dependencies
-`npm install`
-
-Install into system
-`npm link`

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const processSchema = Joi.object().keys({
 });
 
 const lineitemSchema = Joi.object().keys({
-  type: Joi.string().required().valid("sast", "sca", "secret", "dast"),
+  type: Joi.string().required().valid("sast", "secret", "cloud", "sca", "dast"),
   ruleId: Joi.string().required(),
 
   location: Joi.alternatives().conditional("type", {
@@ -162,6 +162,6 @@ console.log(envelopeSchema.validate(reportData).error ?? "envelope  ✅");
 /* validating the line items */
 reportData.output.forEach((lineItem) => {
   console.log(lineitemSchema.validate(lineItem).error ?? lineItem.type + "  ✅");
-  const metadataSchema = { sast: metadataSchemaSAST, secret: metadataSchemaSAST, sca: metadataSchemaSCA, dast: metadataSchemaDAST }[lineItem.type];
+  const metadataSchema = { sast: metadataSchemaSAST, secret: metadataSchemaSAST, cloud: metadataSchemaSAST, sca: metadataSchemaSCA, dast: metadataSchemaDAST }[lineItem.type];
   console.log(metadataSchema.validate(lineItem.metadata).error ?? lineItem.type + " metadata  ✅");
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,73 @@
 {
   "name": "@guardrails/guardrails-engine-output-schema-validator",
-  "version": "1.0.8",
-  "lockfileVersion": 1,
+  "version": "1.1.0",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "@guardrails/guardrails-engine-output-schema-validator",
+      "version": "1.1.0",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "^9.0.0",
+        "joi": "^17.6.0"
+      },
+      "bin": {
+        "guardrails-engine-output-schema-validator": "bin/validator"
+      }
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
+      "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+      "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.3.tgz",
+      "integrity": "sha512-8ncEUtmnTsMmL7z1YPB47kPUq7LpKWJNFPsRzHiIajGC5uXlWGn+AmkYPcHNl8S4tcEGx+cnORnNYaw2wvL+LQ==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
+    },
+    "node_modules/commander": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
+      "integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw==",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/joi": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.0.tgz",
+      "integrity": "sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.3",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    }
+  },
   "dependencies": {
     "@hapi/hoek": {
       "version": "9.1.1",
@@ -18,9 +83,9 @@
       }
     },
     "@sideway/address": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.1.tgz",
-      "integrity": "sha512-+I5aaQr3m0OAmMr7RQ3fR9zx55sejEYR2BFJaxL+zT3VM2611X0SHvPWIbAUBZVTn/YzYKbV8gJ2oT/QELknfQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.3.tgz",
+      "integrity": "sha512-8ncEUtmnTsMmL7z1YPB47kPUq7LpKWJNFPsRzHiIajGC5uXlWGn+AmkYPcHNl8S4tcEGx+cnORnNYaw2wvL+LQ==",
       "requires": {
         "@hapi/hoek": "^9.0.0"
       }
@@ -36,18 +101,18 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "commander": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.1.0.tgz",
-      "integrity": "sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
+      "integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw=="
     },
     "joi": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.0.tgz",
-      "integrity": "sha512-F4WiW2xaV6wc1jxete70Rw4V/VuMd6IN+a5ilZsxG4uYtUXWu2kq9W5P2dz30e7Gmw8RCbY/u/uk+dMPma9tAg==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.0.tgz",
+      "integrity": "sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==",
       "requires": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.0",
+        "@sideway/address": "^4.1.3",
         "@sideway/formula": "^3.0.0",
         "@sideway/pinpoint": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -3,15 +3,19 @@
   "version": "1.1.0",
   "description": "validate the output of engines",
   "main": "index.js",
+  "np": {
+    "branch": "master"
+  },
   "scripts": {
     "test": "sh test/test.sh"
   },
-  "preferGlobal": true,
+  "private": true,
   "bin": "bin/validator",
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "commander": "^7.1.0",
-    "joi": "^17.4.0"
-  }
+    "commander": "^9.0.0",
+    "joi": "^17.6.0"
+  },
+  "files": []
 }


### PR DESCRIPTION
* Swap the README sections, as you can't run it before it's installed.
* Upgrade dependencies
* Add np so we can easily create uniform changelog
* Add empty files array so no non default files can be published to npm
* Remove deprecated `preferGlobal`